### PR TITLE
Compatibility with Django 2.x and Django 3.0

### DIFF
--- a/djangobricks/models.py
+++ b/djangobricks/models.py
@@ -4,8 +4,8 @@ import copy
 from operator import attrgetter
 from itertools import chain
 
-from django.utils import six
-from django.utils.six.moves import range
+import six
+from six.moves import range
 
 if six.PY3:
     def cmp(a, b):

--- a/djangobricks/tests.py
+++ b/djangobricks/tests.py
@@ -9,8 +9,22 @@ from django.db import models
 from django.template import Template, Context
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.six.moves import range
+
+from six.moves import range
+
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    # Django > 2
+    def python_2_unicode_compatible(klass):
+        """
+        A decorator that defines __unicode__ and __str__ methods under Python 2.
+        Under Python 3 it does nothing.
+
+        To support Python 2 and 3 with a single code base, define a __str__ method
+        returning text and apply this decorator to the class.
+        """
+        return klass
 
 from .models import (
     SingleBrick,

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     author = 'Germano Guerrini',
     author_email = 'germano.guerrini@gmail.com',
     url = 'https://github.com/GermanoGuerrini/django-bricks',
+    install_requires=['six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     {py27,py33,py37}-django18,
-    {py27,py33,py37}-django{19,110,20},
-    {py33,py37}-django{30},
+    {py27,py33,py37}-django{19,110},
+    {py33,py37}-django{20,30},
     coverage
 
 [testenv]
@@ -27,5 +27,6 @@ commands =
     coverage run --branch --include={toxinidir}/djangobricks/* --omit={toxinidir}/djangobricks/tests* {envbindir}/django-admin.py test djangobricks
     coveralls
 deps =
+    six
     coveralls
     Django>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35}-django18,
-    {py27,py34,py35}-django{19,110},
+    {py27,py33,py37}-django18,
+    {py27,py33,py37}-django{19,110,20},
+    {py33,py37}-django{30},
     coverage
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = True
 deps =
+    six
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django20: Django<3
+    django30: Django<4
 commands =
     django-admin.py test djangobricks
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py37}-django18,
-    {py27,py33,py37}-django{19,110,20},
-    {py33,py37}-django{30},
+    ; {py27,py33,py37}-django18,
+    {py27,py33,py37}-django{19,110,111},
+    {py33,py37}-django{20,30},
     coverage
 
 [testenv]
@@ -13,10 +13,11 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
     django20: Django<3
     django30: Django<4
 commands =
-    django-admin.py test djangobricks
+    django-admin.py test --verbosity=2 djangobricks
 setenv =
     DJANGO_SETTINGS_MODULE = settings
     PYTHONPATH = {toxinidir}/tests
@@ -28,4 +29,5 @@ commands =
     coveralls
 deps =
     coveralls
-    Django>=1.10,<1.11
+    six
+    Django>=1.11,<4


### PR DESCRIPTION
Added six as a requirement because "django.utils.six" has been removed.